### PR TITLE
Add about content and Twitter link to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # bxvqzgvjaxn5.github.io
+
+Personal landing page for **bxvqzgvjaxn5**, a father and software architect who loves development and crafting things.
+
+Visit the site at [bxvqzgvjaxn5.github.io](https://bxvqzgvjaxn5.github.io) and follow on [Twitter](https://twitter.com/bxvqzgvjaxn5) for updates.

--- a/index.html
+++ b/index.html
@@ -46,9 +46,16 @@
       text-shadow: 0 0 10px rgba(255,255,255,0.6);
     }
     .panel p {
-      margin: 0;
+      margin: 0 0 10px;
       font-size: 1rem;
       text-shadow: 0 0 8px rgba(255,255,255,0.4);
+    }
+    .panel a {
+      color: #1DA1F2;
+      text-decoration: none;
+    }
+    .panel a:hover {
+      text-decoration: underline;
     }
   </style>
 </head>
@@ -58,6 +65,9 @@
     <h1>bxvqzgvjaxn5</h1>
     <h2>father, software architect</h2>
     <p>a guy who loves development and crafting things</p>
+    <p>As a software architect and father, I enjoy turning ideas into reliable solutions and sharing knowledge with the community.</p>
+    <p>When I'm not coding, I'm exploring new technologies, mentoring developers, and building side projects.</p>
+    <p>Find my work on <a href="https://github.com/bxvqzgvjaxn5" target="_blank" rel="noopener noreferrer">GitHub</a> or follow me on <a href="https://twitter.com/bxvqzgvjaxn5" target="_blank" rel="noopener noreferrer">Twitter</a> for updates.</p>
   </div>
   <script>
     const canvas = document.getElementById('background');


### PR DESCRIPTION
## Summary
- expand landing page text and add GitHub and Twitter links
- style anchor tags and adjust paragraph spacing
- document site purpose and Twitter handle in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc290764448320ba91b73dc1c3ba4b