### PR TITLE
Add app list and landing pages

### DIFF
--- a/app-list.html
+++ b/app-list.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>App List</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 40px;
+      background: #f4f4f4;
+      color: #333;
+    }
+    h1 {
+      text-align: center;
+    }
+    .app {
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      margin: 20px auto;
+      max-width: 600px;
+      padding: 20px;
+    }
+    .app h2 {
+      margin-top: 0;
+    }
+    .app a {
+      color: #1DA1F2;
+      text-decoration: none;
+    }
+    .app a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <h1>Our Apps</h1>
+  <div class="app">
+    <h2><a href="apps/taskmaster-pro.html">TaskMaster Pro</a></h2>
+    <p>Organize tasks and boost productivity with smart scheduling and reminders.</p>
+  </div>
+  <div class="app">
+    <h2><a href="apps/fitjourney.html">FitJourney</a></h2>
+    <p>Track workouts, monitor progress, and stay motivated on your fitness path.</p>
+  </div>
+  <div class="app">
+    <h2><a href="apps/mindfulnotes.html">MindfulNotes</a></h2>
+    <p>Capture thoughts and practice mindfulness with a serene note-taking experience.</p>
+  </div>
+</body>
+</html>

--- a/apps/fitjourney.html
+++ b/apps/fitjourney.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FitJourney</title>
+  <style>
+    body {
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+      margin: 0;
+      background: linear-gradient(135deg, #ff7e5f, #feb47b);
+      color: #fff;
+    }
+    header {
+      text-align: center;
+      padding: 60px 20px;
+    }
+    header h1 {
+      font-size: 3rem;
+      margin: 0;
+    }
+    header p {
+      margin: 10px 0 0;
+      font-size: 1.2rem;
+    }
+    main {
+      background: rgba(0,0,0,0.3);
+      padding: 20px;
+    }
+    section {
+      margin: 40px auto;
+      max-width: 800px;
+    }
+    footer {
+      text-align: center;
+      padding: 20px;
+      background: rgba(0,0,0,0.3);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>FitJourney</h1>
+    <p>"Every step counts"</p>
+  </header>
+  <main>
+    <section>
+      <h2>Introduction</h2>
+      <p>FitJourney helps you stay active by tracking workouts, monitoring progress, and providing personalized fitness goals.</p>
+    </section>
+    <section>
+      <h2>User Journeys</h2>
+      <ul>
+        <li>Log daily workouts and compare performance over time.</li>
+        <li>Join challenges with friends for extra motivation.</li>
+        <li>Receive tailored workout plans based on your goals.</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Pricing</h2>
+      <ul>
+        <li>Free: Basic workout logging and progress charts.</li>
+        <li>Plus: $8/month for personalized plans and challenge features.</li>
+        <li>Coach: $20/month for one-on-one virtual coaching.</li>
+      </ul>
+    </section>
+  </main>
+  <footer>
+    &copy; 2024 FitJourney. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/apps/mindfulnotes.html
+++ b/apps/mindfulnotes.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MindfulNotes</title>
+  <style>
+    body {
+      font-family: 'Georgia', serif;
+      margin: 0;
+      background: #f0e6ff;
+      color: #333;
+    }
+    header {
+      text-align: center;
+      padding: 50px 20px;
+      background: #d8c7ff;
+    }
+    main {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 20px;
+      line-height: 1.6;
+    }
+    footer {
+      text-align: center;
+      padding: 20px;
+      background: #d8c7ff;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>MindfulNotes</h1>
+    <p>"Write with clarity, reflect with calm"</p>
+  </header>
+  <main>
+    <section>
+      <h2>Introduction</h2>
+      <p>MindfulNotes combines note-taking with mindfulness prompts to help you organize thoughts and maintain mental well-being.</p>
+    </section>
+    <section>
+      <h2>User Journeys</h2>
+      <ul>
+        <li>Capture ideas and reflect with guided prompts.</li>
+        <li>Create journals for different aspects of your life.</li>
+        <li>Review past notes to track personal growth.</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Pricing</h2>
+      <ul>
+        <li>Free: Unlimited notes with basic prompts.</li>
+        <li>Premium: $4/month for advanced reflections and export options.</li>
+        <li>Lifetime: $50 one-time purchase for full access.</li>
+      </ul>
+    </section>
+  </main>
+  <footer>
+    &copy; 2024 MindfulNotes. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/apps/taskmaster-pro.html
+++ b/apps/taskmaster-pro.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TaskMaster Pro</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      background: #2c3e50;
+      color: #ecf0f1;
+    }
+    header {
+      background: #1abc9c;
+      padding: 40px 20px;
+      text-align: center;
+    }
+    header h1 {
+      margin: 0;
+    }
+    header p {
+      margin: 10px 0 0;
+      font-style: italic;
+    }
+    main {
+      padding: 20px;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+    section {
+      margin-bottom: 40px;
+    }
+    footer {
+      text-align: center;
+      padding: 20px;
+      background: #1abc9c;
+      color: #2c3e50;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>TaskMaster Pro</h1>
+    <p>"Dominate your day with precision"</p>
+  </header>
+  <main>
+    <section>
+      <h2>Introduction</h2>
+      <p>TaskMaster Pro streamlines your workflow with intelligent task management and scheduling tools designed for busy professionals.</p>
+    </section>
+    <section>
+      <h2>User Journeys</h2>
+      <ul>
+        <li>Plan your day with drag-and-drop task scheduling.</li>
+        <li>Receive smart reminders before deadlines.</li>
+        <li>Collaborate with teammates on shared projects.</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Pricing</h2>
+      <ul>
+        <li>Free: Basic task tracking for individuals.</li>
+        <li>Pro: $5/month for advanced scheduling and integrations.</li>
+        <li>Enterprise: Contact us for custom solutions.</li>
+      </ul>
+    </section>
+  </main>
+  <footer>
+    &copy; 2024 TaskMaster Pro. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
     <p>As a software architect and father, I enjoy turning ideas into reliable solutions and sharing knowledge with the community.</p>
     <p>When I'm not coding, I'm exploring new technologies, mentoring developers, and building side projects.</p>
     <p>Find my work on <a href="https://github.com/bxvqzgvjaxn5" target="_blank" rel="noopener noreferrer">GitHub</a> or follow me on <a href="https://twitter.com/bxvqzgvjaxn5" target="_blank" rel="noopener noreferrer">Twitter</a> for updates.</p>
+    <p>Explore my <a href="app-list.html">app list</a> for more projects.</p>
   </div>
   <script>
     const canvas = document.getElementById('background');


### PR DESCRIPTION
## Summary
- Add `app-list.html` listing three sample apps
- Create themed landing pages for TaskMaster Pro, FitJourney, and MindfulNotes
- Link main page to app list and move app pages under `apps/`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc354129c483209a1d5b3d51e22df5