### PR TITLE
Add navigation and black theme landing page

### DIFF
--- a/app-list.html
+++ b/app-list.html
@@ -19,11 +19,13 @@
       margin-bottom: 20px;
     }
     .app h3 { margin-top: 0; }
-    .app a { color: #0077cc; text-decoration: none; }
-    .app a:hover { text-decoration: underline; }
   </style>
 </head>
 <body>
+  <nav class="main-nav">
+    <a href="index.html">Home</a>
+    <a href="app-list.html">Apps</a>
+  </nav>
   <section class="hero">
     <h1>Our Apps</h1>
     <p>Discover the tools that power your workflow</p>

--- a/apps/fitjourney.html
+++ b/apps/fitjourney.html
@@ -7,6 +7,10 @@
   <link rel="stylesheet" href="../styles.css" />
 </head>
 <body>
+  <nav class="main-nav">
+    <a href="../index.html">Home</a>
+    <a href="../app-list.html">Apps</a>
+  </nav>
   <section class="hero">
     <h1>FitJourney</h1>
     <p>Every step counts</p>

--- a/apps/mindfulnotes.html
+++ b/apps/mindfulnotes.html
@@ -7,6 +7,10 @@
   <link rel="stylesheet" href="../styles.css" />
 </head>
 <body>
+  <nav class="main-nav">
+    <a href="../index.html">Home</a>
+    <a href="../app-list.html">Apps</a>
+  </nav>
   <section class="hero">
     <h1>MindfulNotes</h1>
     <p>Write with clarity, reflect with calm</p>

--- a/apps/taskmaster-pro.html
+++ b/apps/taskmaster-pro.html
@@ -7,6 +7,10 @@
   <link rel="stylesheet" href="../styles.css" />
 </head>
 <body>
+  <nav class="main-nav">
+    <a href="../index.html">Home</a>
+    <a href="../app-list.html">Apps</a>
+  </nav>
   <section class="hero">
     <h1>TaskMaster Pro</h1>
     <p>Dominate your day with precision</p>

--- a/index.html
+++ b/index.html
@@ -6,10 +6,15 @@
   <title>bxvqzgvjaxn5</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
+<body class="black-theme">
+  <nav class="main-nav">
+    <a href="index.html">Home</a>
+    <a href="app-list.html">Apps</a>
+  </nav>
   <section class="hero">
     <h1>bxvqzgvjaxn5</h1>
     <p>Father, software architect</p>
+    <p><a href="app-list.html">Explore our apps</a></p>
     <img src="https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=1200" alt="Developer at work" />
   </section>
 

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,55 @@ body {
   background: #f9f9f9;
   color: #333;
 }
+a {
+  color: #0645ad;
+}
+a:visited {
+  color: #0b0080;
+}
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.main-nav {
+  display: flex;
+  gap: 15px;
+  padding: 10px 20px;
+  background: #f0f0f0;
+}
+.main-nav a {
+  text-decoration: none;
+}
+.main-nav a:hover,
+.main-nav a:focus {
+  text-decoration: underline;
+}
+
+.black-theme {
+  background: #000;
+  color: #fff;
+}
+.black-theme .main-nav {
+  background: #000;
+}
+.black-theme .main-nav a {
+  color: #1e90ff;
+}
+.black-theme .hero {
+  background: linear-gradient(135deg, #000, #333);
+}
+.black-theme .pricing,
+.black-theme .journey {
+  background: #111;
+}
+.black-theme .pricing-card {
+  background: #222;
+}
+.black-theme .icon {
+  background: #333;
+  color: #fff;
+}
 
 .hero {
   padding: 80px 20px;


### PR DESCRIPTION
## Summary
- restore consistent link styling and navigation between pages
- convert home page into a black-themed landing page with app links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4c1327648320b48a1f4f3cf32a25