### PR TITLE
Add animated uniform logos to FitJourney landing page

### DIFF
--- a/apps/fitjourney.html
+++ b/apps/fitjourney.html
@@ -25,9 +25,29 @@
     .hero h1 { font-size: 3rem; margin-bottom: 20px; }
     .hero p { font-size: 1.2rem; margin-bottom: 40px; }
     .hero .cta { margin: 0 10px; }
-    .logos { display: flex; justify-content: center; gap: 40px; padding: 40px 20px; flex-wrap: wrap; }
-    .logos img { width: 100px; height: auto; filter: grayscale(100%); opacity: 0.7; transition: filter 0.3s, opacity 0.3s; }
-    .logos img:hover { filter: none; opacity: 1; }
+    .logos {
+      overflow: hidden;
+      padding: 40px 0;
+    }
+    .logos-track {
+      display: flex;
+      align-items: center;
+      gap: 40px;
+      animation: scroll 40s linear infinite;
+      animation-direction: reverse;
+    }
+    .logos-track img {
+      height: 50px;
+      width: auto;
+      filter: grayscale(100%);
+      opacity: 0.7;
+      transition: filter 0.3s, opacity 0.3s;
+    }
+    .logos-track img:hover { filter: none; opacity: 1; }
+    @keyframes scroll {
+      from { transform: translateX(0); }
+      to { transform: translateX(-50%); }
+    }
     .features { padding: 80px 20px; background: #f9f9f9; }
     .features h2 { text-align: center; margin-bottom: 60px; }
     .feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 40px; max-width: 1200px; margin: 0 auto; }
@@ -55,7 +75,7 @@
       .hero { padding: 60px 20px; }
       .hero h1 { font-size: 2rem; }
       .hero .cta { margin: 10px 0; width: 100%; max-width: 250px; }
-      .logos { gap: 20px; }
+      .logos-track { gap: 20px; }
     }
   </style>
 </head>
@@ -78,10 +98,24 @@
   </section>
 
   <section class="logos">
-    <img src="https://logo.clearbit.com/nike.com?size=100" alt="Nike logo" />
-    <img src="https://logo.clearbit.com/adidas.com?size=100" alt="Adidas logo" />
-    <img src="https://logo.clearbit.com/underarmour.com?size=100" alt="Under Armour logo" />
-    <img src="https://logo.clearbit.com/fitbit.com?size=100" alt="Fitbit logo" />
+    <div class="logos-track">
+      <img src="https://logo.clearbit.com/nike.com?size=100" alt="Nike logo" />
+      <img src="https://logo.clearbit.com/adidas.com?size=100" alt="Adidas logo" />
+      <img src="https://logo.clearbit.com/underarmour.com?size=100" alt="Under Armour logo" />
+      <img src="https://logo.clearbit.com/fitbit.com?size=100" alt="Fitbit logo" />
+      <img src="https://logo.clearbit.com/reebok.com?size=100" alt="Reebok logo" />
+      <img src="https://logo.clearbit.com/asics.com?size=100" alt="Asics logo" />
+      <img src="https://logo.clearbit.com/puma.com?size=100" alt="Puma logo" />
+      <img src="https://logo.clearbit.com/garmin.com?size=100" alt="Garmin logo" />
+      <img src="https://logo.clearbit.com/nike.com?size=100" alt="Nike logo" />
+      <img src="https://logo.clearbit.com/adidas.com?size=100" alt="Adidas logo" />
+      <img src="https://logo.clearbit.com/underarmour.com?size=100" alt="Under Armour logo" />
+      <img src="https://logo.clearbit.com/fitbit.com?size=100" alt="Fitbit logo" />
+      <img src="https://logo.clearbit.com/reebok.com?size=100" alt="Reebok logo" />
+      <img src="https://logo.clearbit.com/asics.com?size=100" alt="Asics logo" />
+      <img src="https://logo.clearbit.com/puma.com?size=100" alt="Puma logo" />
+      <img src="https://logo.clearbit.com/garmin.com?size=100" alt="Garmin logo" />
+    </div>
   </section>
 
   <section id="features" class="features">


### PR DESCRIPTION
## Summary
- Add eight-brand scrolling carousel to FitJourney logos section
- Standardize logo heights and animate slow left-to-right flow
- Tweak mobile styles for consistent spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7ef49a208320baedd5adaa5a58ff